### PR TITLE
Add travis-debug command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Tools for Linuxbrew developers
 + **pull-bottle**: Merge a pull request and update both the Mac and Linux bottles
 + **pull-linux**: Merge a pull request and update the Linuxbrew bottle
 + **squash-bottle-pr**: Squash the last two commits created by build-bottle-pr
++ **travis-debug**: Debug a failing formula on Travis CI
 
 ## Installation
 

--- a/cmd/brew-travis-debug.rb
+++ b/cmd/brew-travis-debug.rb
@@ -1,0 +1,14 @@
+#: * `travis-debug` [`--pull`]:
+#:   Debug a formula on Travis CI.
+#:   If `--pull` is passed, pull a fresh image from Docker Hub.
+
+module Homebrew
+  def travis_debug
+    odie 'Please run "brew install docker".' unless which "docker"
+    image_tag = "linuxbrew/travis"
+    safe_system "docker", "pull", image_tag if ARGV.include? "--pull"
+    exec "docker", "run", "-it", image_tag, "/bin/bash"
+  end
+end
+
+Homebrew.travis_debug


### PR DESCRIPTION
This imports rwhogg/travis-debug into Linuxbrew.

I've rewritten it in Ruby rather than the original, which was in idiosyncratic Python. <strike>Also, it inlines the Dockerfile to avoid polluting the repo.</strike>

EDIT: It now uses https://github.com/Linuxbrew/docker/blob/master/travis/Dockerfile for its Dockerfile