### PR TITLE
build-bottle-pr: Fix syntax error

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -97,7 +97,7 @@ module Homebrew
         safe_system "git", "push", remote, branch
         ohai "#{formula}: Using remote '#{remote}' to submit Pull Request" if ARGV.verbose?
         safe_system "hub", "pull-request",
-          "-h", "#{remote}:#{branch}", "-m", message
+          "-h", "#{remote}:#{branch}", "-m", message,
           *("--browse" unless ENV["BROWSER"].nil? && ENV["HOMEBREW_BROWSER"].nil?)
       end
       safe_system "git", "checkout", "master"


### PR DESCRIPTION
Missing a comma.

```bash
% brew build-bottle-pr --dry-run ratfor
Error: /home/linuxbrew/.linuxbrew/Library/Taps/linuxbrew/homebrew-developer/cmd/brew-build-bottle-pr.rb:101: syntax error, unexpected '\n', expecting &. or :: or '[' or '.'
/home/linuxbrew/.linuxbrew/Library/Taps/linuxbrew/homebrew-developer/cmd/brew-build-bottle-pr.rb:133: syntax error, unexpected end-of-input, expecting keyword_end
/home/linuxbrew/.linuxbrew/Cellar/ruby/2.4.0/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/home/linuxbrew/.linuxbrew/Cellar/ruby/2.4.0/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/home/linuxbrew/.linuxbrew/Library/Homebrew/brew.rb:24:in `require?'
/home/linuxbrew/.linuxbrew/Library/Homebrew/brew.rb:100:in `<main>'
```