### PR TITLE
brew-build-bottle-pr: add bottle label and assignee for PRs

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -112,6 +112,7 @@ module Homebrew
         ohai "#{formula}: Using remote '#{remote}' to submit Pull Request" if ARGV.verbose?
         safe_system "hub", "pull-request",
           "-h", "#{remote}:#{branch}", "-m", message,
+          "-l", "bottle", "-a", remote,
           *("--browse" unless ENV["BROWSER"].nil? && ENV["HOMEBREW_BROWSER"].nil?)
       end
       safe_system "git", "checkout", "master"


### PR DESCRIPTION
hub can add assignees and labels via `-a` and `-l` flags correspondingly.
Since the person submitting a PR should be responsible for it, let's do it automatically.