### PR TITLE
brew-build-bottle-pr: audit formulae before submitting PRs

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -91,12 +91,13 @@ module Homebrew
     return ohai "#{formula}: Skipping because it has a bottle already" if formula.bottle_specification.tag?(tag)
     return ohai "#{formula}: Skipping because #{tap} does not support Linux" if slug(tap)[/^Homebrew/] && tap.repo != "science"
     return if open_pull_request? formula
-    system HOMEBREW_BREW_FILE, "audit", "--strict", "--online", formula.path
-    odie "Please fix audit failure for #{formula}" unless $?.success?
 
     @n += 1
     return ohai "#{formula}: Skipping because GitHub rate limits pull requests (limit = #{limit})." if @n > limit
 
+    system HOMEBREW_BREW_FILE, "audit", "--strict", "--online", formula.path
+    odie "Please fix audit failure for #{formula}" unless $?.success?
+    
     message = "#{formula}: Build a bottle for Linuxbrew"
     oh1 "#{@n}. #{message}"
 

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -79,7 +79,7 @@ module Homebrew
 
   def audit(formulae)
     formulae.each do |formula|
-      safe_system "brew", "audit", "--strict", "--online", formula
+      system HOMEBREW_BREW_FILE, "audit", "--strict", "--online", formula.path
       odie "Please fix audit failure for #{formula}" unless $?.success?
     end
   end

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -77,6 +77,13 @@ module Homebrew
     end
   end
 
+  def audit(formulae)
+    formulae.each do |formula|
+      safe_system "brew", "audit", "--strict", "--online", formula
+      odie "Please fix audit failue with #{formula}" unless $?.success?
+    end
+  end
+
   # The number of bottled formula.
   @n = 0
 
@@ -140,6 +147,7 @@ module Homebrew
       formulae = deps.map { |f| Formula[f] } + formulae
     end
     check_remotes formulae
+    audit formulae
     formulae.each { |f| build_bottle f }
   end
 end

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -80,7 +80,7 @@ module Homebrew
   def audit(formulae)
     formulae.each do |formula|
       safe_system "brew", "audit", "--strict", "--online", formula
-      odie "Please fix audit failue with #{formula}" unless $?.success?
+      odie "Please fix audit failure for #{formula}" unless $?.success?
     end
   end
 

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -77,13 +77,6 @@ module Homebrew
     end
   end
 
-  def audit(formulae)
-    formulae.each do |formula|
-      system HOMEBREW_BREW_FILE, "audit", "--strict", "--online", formula.path
-      odie "Please fix audit failure for #{formula}" unless $?.success?
-    end
-  end
-
   # The number of bottled formula.
   @n = 0
 
@@ -98,6 +91,8 @@ module Homebrew
     return ohai "#{formula}: Skipping because it has a bottle already" if formula.bottle_specification.tag?(tag)
     return ohai "#{formula}: Skipping because #{tap} does not support Linux" if slug(tap)[/^Homebrew/] && tap.repo != "science"
     return if open_pull_request? formula
+    system HOMEBREW_BREW_FILE, "audit", "--strict", "--online", formula.path
+    odie "Please fix audit failure for #{formula}" unless $?.success?
 
     @n += 1
     return ohai "#{formula}: Skipping because GitHub rate limits pull requests (limit = #{limit})." if @n > limit
@@ -147,7 +142,6 @@ module Homebrew
       formulae = deps.map { |f| Formula[f] } + formulae
     end
     check_remotes formulae
-    audit formulae
     formulae.each { |f| build_bottle f }
   end
 end


### PR DESCRIPTION
When we submit PRs to build bottles, CI builds will fail when formula don't pass audit checks. We should run audit automatically before submitting a PR... hence, this PR :)