### PR TITLE
brew-merge-homebrew: specify several merges in one command

### DIFF
--- a/cmd/brew-merge-homebrew.rb
+++ b/cmd/brew-merge-homebrew.rb
@@ -38,7 +38,7 @@ module Homebrew
 
     safe_system git, "pull", "--ff-only", "origin", "master"
     safe_system git, "fetch", "homebrew"
-    homebrew_commits.each { |sha1| git_merge_commit sha1 }
+    homebrew_commits.each { |sha1| git_merge_commit sha1, fast_forward }
   end
 
   def resolve_conflicts

--- a/cmd/brew-merge-homebrew.rb
+++ b/cmd/brew-merge-homebrew.rb
@@ -19,6 +19,18 @@ module Homebrew
     @git ||= Utils.git_path
   end
 
+  def git_merge_commit(sha1, fast_forward: false)
+    start_sha1 = Utils.popen_read(git, "rev-parse", "HEAD").chomp
+    end_sha1 = Utils.popen_read(git, "rev-parse", sha1).chomp
+
+    puts "Start commit: #{start_sha1}"
+    puts "End   commit: #{end_sha1}"
+
+    args = []
+    args << "--ff-only" if fast_forward
+    system git, "merge", *args, sha1, "-m", "Merge branch homebrew/master into linuxbrew/master"
+  end
+
   def git_merge(fast_forward: false)
     remotes = Utils.popen_read(git, "remote").split
     odie "Please add a remote with the name 'homebrew' in #{Dir.pwd}" unless remotes.include? "homebrew"
@@ -26,17 +38,7 @@ module Homebrew
 
     safe_system git, "pull", "--ff-only", "origin", "master"
     safe_system git, "fetch", "homebrew"
-    homebrew_commits.each do |hbc|
-      start_sha1 = Utils.popen_read(git, "rev-parse", "HEAD").chomp
-      end_sha1 = Utils.popen_read(git, "rev-parse", hbc).chomp
-
-      puts "Start commit: #{start_sha1}"
-      puts "End   commit: #{end_sha1}"
-
-      args = []
-      args << "--ff-only" if fast_forward
-      system git, "merge", *args, hbc, "-m", "Merge branch homebrew/master into linuxbrew/master"
-    end
+    homebrew_commits.each { |sha1| git_merge_commit sha1 }
   end
 
   def resolve_conflicts

--- a/cmd/brew-merge-homebrew.rb
+++ b/cmd/brew-merge-homebrew.rb
@@ -48,7 +48,7 @@ module Homebrew
     safe_system HOMEBREW_BREW_FILE, "style", *conflicts
     safe_system git, "diff", "--check"
     safe_system git, "add", "--", *conflicts
-    return conflicts
+    conflicts
   end
 
   def merge_brew

--- a/cmd/brew-merge-homebrew.rb
+++ b/cmd/brew-merge-homebrew.rb
@@ -48,7 +48,7 @@ module Homebrew
     safe_system HOMEBREW_BREW_FILE, "style", *conflicts
     safe_system git, "diff", "--check"
     safe_system git, "add", "--", *conflicts
-    conflicts
+    return conflicts
   end
 
   def merge_brew
@@ -153,7 +153,7 @@ module Homebrew
 
   def homebrew_commits
     if ARGV.named.empty?
-      "homebrew/master"
+      ["homebrew/master"]
     else
       ARGV.named.each { |hbc| safe_system git, "rev-parse", hbc }
       ARGV.named

--- a/cmd/brew-merge-homebrew.rb
+++ b/cmd/brew-merge-homebrew.rb
@@ -157,7 +157,7 @@ module Homebrew
     if ARGV.named.empty?
       ["homebrew/master"]
     else
-      ARGV.named.each { |hbc| safe_system git, "rev-parse", "--verify", hbc }
+      ARGV.named.each { |sha1| safe_system git, "rev-parse", "--verify", sha1 }
       ARGV.named
     end
   end

--- a/cmd/brew-merge-homebrew.rb
+++ b/cmd/brew-merge-homebrew.rb
@@ -155,7 +155,7 @@ module Homebrew
     if ARGV.named.empty?
       ["homebrew/master"]
     else
-      ARGV.named.each { |hbc| safe_system git, "rev-parse", hbc }
+      ARGV.named.each { |hbc| safe_system git, "rev-parse", "--verify", hbc }
       ARGV.named
     end
   end


### PR DESCRIPTION
The idea is that with this change we should be able to use the following syntax:
```
brew merge-homebrew --core sha1 sha2 sha3
```
and it should create the following merge commits:
`origin -> sha1`, `sha1 -> sha2`, `sha2 -> sha3`

Further improvements will be to automatically split homebrew commits into patches based on which formulas are updated