### PR TITLE
pull-circle: Fix punctuation in bottle filenames

### DIFF
--- a/cmd/brew-pull-circle.rb
+++ b/cmd/brew-pull-circle.rb
@@ -45,9 +45,10 @@ module Homebrew
 
     mkdir "#{tap}/#{issue}" do
       urls.each do |url|
-        puts File.basename(url)
+        filename = File.basename(url).gsub("%25", "%").gsub("%2B", "+").gsub("%40", "@")
+        puts filename
         puts url if ARGV.verbose?
-        curl "-O", url
+        curl "-o", filename, url
       end
       ci_upload issue if ARGV.include? "--ci-upload"
     end


### PR DESCRIPTION
Fix punctuation, specifically + and @, in bottle filenames.
Replace %2B with + and %40 with @.