### PR TITLE
build-bottle-pr: Do online rather than strict audit

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -107,7 +107,7 @@ module Homebrew
     @n += 1
     return ohai "#{formula}: Skipping because GitHub rate limits pull requests (limit = #{limit})." if @n > limit
 
-    system HOMEBREW_BREW_FILE, "audit", "--strict", formula.path
+    system HOMEBREW_BREW_FILE, "audit", "--online", formula.path
     odie "Please fix audit failure for #{formula}" unless $?.success?
 
     message = "#{formula}: Build a bottle for Linuxbrew"


### PR DESCRIPTION
<strike>
A lot of formulae are missing tests upstream, causing
audit failures. This provides a way for maintainers to
ignore them when submitting bottling PR's while
upstream finishes working on
https://github.com/Homebrew/homebrew-core/issues/11898
</strike>
 
Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

This PR is now about `brew build-bottle-pr` doing an online audit rather than a strict audit so missing tests (of which there are a lot) don't prevent making the PR.