### PR TITLE
travis-debug: Use module_function

### DIFF
--- a/cmd/brew-travis-debug.rb
+++ b/cmd/brew-travis-debug.rb
@@ -3,6 +3,8 @@
 #:   If `--pull` is passed, pull a fresh image from Docker Hub.
 
 module Homebrew
+  module_function
+
   def travis_debug
     odie 'Please run "brew install docker".' unless which "docker"
     image_tag = "linuxbrew/travis"


### PR DESCRIPTION
Avoid deprecation warning.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

Fix error:

```
Error: Calling Homebrew#travis_debug is deprecated!
Use 'module_function' or 'def self.travis_debug' to convert it to a class method instead.
/home/linuxbrew/.linuxbrew/Library/Taps/linuxbrew/homebrew-developer/cmd/brew-travis-debug.rb:14:in `<top (required)>'
Please report this to the linuxbrew/developer tap!
```