### PR TITLE
build-bottle-pr: Rescue NameError when MacOSRequirement is not defined

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -163,7 +163,7 @@ module Homebrew
 
   def depends_on_macos?(formula)
     formula.requirements.any? { |req| req.instance_of? MacOSRequirement }
-  rescue
+  rescue NameError
     # MacOSRequirement is not defined in upstream brew
     false
   end


### PR DESCRIPTION
Signed-off-by: Bob W. Hogg <rwhogg@linux.com>