### PR TITLE
brew-test-bot-docker: tap linuxbrew/homebrew-xorg

### DIFF
--- a/cmd/brew-test-bot-docker.rb
+++ b/cmd/brew-test-bot-docker.rb
@@ -17,6 +17,7 @@ module Homebrew
       "linuxbrew/linuxbrew",
       "sh", "-c", <<-EOS.undent
         sudo apt-get install -y python
+        brew tap linuxbrew/homebrew-org
         mkdir linuxbrew-test-bot
         cd linuxbrew-test-bot
         brew test-bot #{argv}


### PR DESCRIPTION
This is needed to build bottles that need formulae
from homebrew-xorg (for example vtk).