### PR TITLE
merge-homebrew: Allow using git mergetool

### DIFF
--- a/cmd/brew-merge-homebrew.rb
+++ b/cmd/brew-merge-homebrew.rb
@@ -4,9 +4,6 @@
 #:   If `--brew` is passed, merge Homebrew/brew into Linuxbrew/brew.
 #:   If `--core` is passed, merge Homebrew/homebrew-core into Linuxbrew/homebrew-core.
 #:   If <commit> is passed, merge only up to that upstream SHA-1 commit.
-#:
-#:   If HOMEBREW_MERGETOOL is set, run "git mergetool" instead of opening conflicting
-#:   files in an editor.
 
 require "date"
 
@@ -22,6 +19,10 @@ module Homebrew
 
   def git
     @git ||= Utils.git_path
+  end
+
+  def has_mergetool
+    @mergetool ||= system "git config merge.tool >/dev/null 2>/dev/null"
   end
 
   def git_merge_commit(sha1, fast_forward: false)
@@ -51,7 +52,7 @@ module Homebrew
     return conflicts if conflicts.empty?
     oh1 "Conflicts"
     puts conflicts.join(" ")
-    unless ENV["HOMEBREW_MERGETOOL"].nil?
+    if has_mergetool
       safe_system "git", "mergetool"
     else
       safe_system *editor, *conflicts

--- a/cmd/brew-merge-homebrew.rb
+++ b/cmd/brew-merge-homebrew.rb
@@ -4,6 +4,9 @@
 #:   If `--brew` is passed, merge Homebrew/brew into Linuxbrew/brew.
 #:   If `--core` is passed, merge Homebrew/homebrew-core into Linuxbrew/homebrew-core.
 #:   If <commit> is passed, merge only up to that upstream SHA-1 commit.
+#:
+#:   If HOMEBREW_MERGETOOL is set, run "git mergetool" instead of opening conflicting
+#:   files in an editor.
 
 require "date"
 
@@ -48,7 +51,11 @@ module Homebrew
     return conflicts if conflicts.empty?
     oh1 "Conflicts"
     puts conflicts.join(" ")
-    safe_system *editor, *conflicts
+    unless ENV["HOMEBREW_MERGETOOL"].nil?
+      safe_system "git", "mergetool"
+    else
+      safe_system *editor, *conflicts
+    end
     safe_system HOMEBREW_BREW_FILE, "style", *conflicts
     safe_system git, "diff", "--check"
     safe_system git, "add", "--", *conflicts

--- a/cmd/brew-merge-homebrew.rb
+++ b/cmd/brew-merge-homebrew.rb
@@ -21,8 +21,8 @@ module Homebrew
     @git ||= Utils.git_path
   end
 
-  def has_mergetool?
-    @mergetool ||= system "git config merge.tool >/dev/null 2>/dev/null"
+  def mergetool?
+    @mergetool = system "git config merge.tool >/dev/null 2>/dev/null" if @mergetool.nil?
   end
 
   def git_merge_commit(sha1, fast_forward: false)
@@ -52,7 +52,7 @@ module Homebrew
     return conflicts if conflicts.empty?
     oh1 "Conflicts"
     puts conflicts.join(" ")
-    if has_mergetool?
+    if mergetool?
       safe_system "git", "mergetool"
     else
       safe_system *editor, *conflicts

--- a/cmd/brew-merge-homebrew.rb
+++ b/cmd/brew-merge-homebrew.rb
@@ -21,7 +21,7 @@ module Homebrew
     @git ||= Utils.git_path
   end
 
-  def has_mergetool
+  def has_mergetool?
     @mergetool ||= system "git config merge.tool >/dev/null 2>/dev/null"
   end
 
@@ -52,7 +52,7 @@ module Homebrew
     return conflicts if conflicts.empty?
     oh1 "Conflicts"
     puts conflicts.join(" ")
-    if has_mergetool
+    if has_mergetool?
       safe_system "git", "mergetool"
     else
       safe_system *editor, *conflicts


### PR DESCRIPTION
Use "git mergetool" if HOMEBREW_MERGETOOL is set.
I'm not a fan of resolving conflicts with a normal
editor.

Closes #43

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>