### PR TITLE
pull-linux: temp fix for patch redirects

### DIFF
--- a/cmd/brew-pull-linux.rb
+++ b/cmd/brew-pull-linux.rb
@@ -298,7 +298,7 @@ module Homebrew
       extra_msg = @description ? "(#{@description})" : nil
       ohai "Fetching patch #{extra_msg}"
       puts "Patch: #{patch_url}"
-      curl patch_url, "-s", "-o", patchpath
+      curl patch_url, "-s", "-L", "-o", patchpath
     end
 
     def apply_patch


### PR DESCRIPTION
Fixes the following error caused by not following redirects while fetching the patch:

```
/usr/local/bin/brew pull-linux --bottle -vd https://github.com/Homebrew/homebrew-science/pull/6194
==> Fetching patch 
Patch: https://github.com/Homebrew/homebrew-science/pull/6194.patch
/usr/bin/curl --show-error --user-agent Homebrew/1.3.1-97-g6d393de (Macintosh; Intel Mac OS X 10.12.6) curl/7.54.0 --fail https://github.com/Homebrew/homebrew-science/pull/6194.patch -s -o /Users/jonchang/Library/Caches/Homebrew/6194.patch
==> Applying patch
git am --whitespace=fix -3 /Users/jonchang/Library/Caches/Homebrew/6194.patch
Patch format detection failed.
fatal: Resolve operation not in progress, we are not resuming.
Error: Patch failed to apply: aborted.
Error: Kernel.exit
```