### PR TITLE
brew-pull-circle.rb: Fix folder creation

### DIFF
--- a/cmd/brew-pull-circle.rb
+++ b/cmd/brew-pull-circle.rb
@@ -9,6 +9,8 @@
 #:    `--git-name=<git-name>` Set the Git author/committer names to the given name.
 #:    `--git-email=<git-email>` Set the Git author/committer email to the given email.
 
+require 'fileutils'
+
 module Homebrew
   module_function
 
@@ -54,7 +56,7 @@ module Homebrew
     odie json["message"] if json.is_a? Hash
     urls = json.map { |x| x["url"] }.uniq
 
-    mkdir "#{tap}/#{issue}" do
+    FileUtils::mkdir_p "#{tap}/#{issue}" do
       urls.each do |url|
         filename = File.basename(url).gsub("%25", "%").gsub("%2B", "+").gsub("%40", "@")
         puts filename


### PR DESCRIPTION
Fixes:
 /tmp/brew/bin/brew [ 'pull-circle',
'--ci-upload',
'--keep-old',
'https://github.com/Linuxbrew/homebrew-core/pull/8436' ] ==> homebrew/core#8436
https://circleci.com/api/v1.1/project/github/Linuxbrew/homebrew-core/latest/artifacts?branch=pull/8436
Error: No such file or directory @ dir_s_mkdir - homebrew/core/8436