### PR TITLE
brew-build-bottle-pr: remove online audit step

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -127,7 +127,7 @@ module Homebrew
     @n += 1
     return ohai "#{formula}: Skipping because GitHub rate limits pull requests (limit = #{limit})." if @n > limit
 
-    system HOMEBREW_BREW_FILE, "audit", "--online", formula.path
+    system HOMEBREW_BREW_FILE, "audit", formula.path
     opoo "Please fix audit failure for #{formula}" unless $CHILD_STATUS.success?
 
     message = "#{formula}: Build a bottle for Linuxbrew"


### PR DESCRIPTION
This allows to speed up the command a lot (no url checks anymore, which are really slow when a formula has a lot of resources).
Audit failures are quite rare, and the audit is run on the CI anyway.