### PR TITLE
brew-build-bottle-pr: ignore minimum mac os requirements

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -162,10 +162,7 @@ module Homebrew
   end
 
   def depends_on_macos?(formula)
-    formula.requirements.any? { |req| req.instance_of? MacOSRequirement }
-  rescue NameError
-    # MacOSRequirement is not defined in upstream brew
-    false
+    formula.requirements.any? { |req| (req.instance_of? MacOSRequirement) && !req.minimum_version_specified? }
   end
 
   def shell(cmd)


### PR DESCRIPTION
When building a bottle PR, we should be ignoring cases like:
depends_on :macos => :lion

One solution would be to safeguard all these lines with an "OS.mac?"
check, but as I am running this on my mac, it does not make sense.