### PR TITLE
brew-build-bottle-pr: Fix command

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -148,9 +148,9 @@ module Homebrew
       File.open(formula.path, "r+") do |f|
         s = f.read
         f.rewind
-        f.write "# #{message}\n#{s}" unless ARGV.dry_run?
+        f.write "# #{message}\n#{s}" if ARGV.value("dry_run").nil?
       end
-      unless ARGV.dry_run?
+      if ARGV.value("dry_run").nil?
         keep_old if ARGV.include? "--keep-old"
         safe_system "git", "commit", formula.path, "-m", message
         unless Utils.popen_read("git", "branch", "-r", "--list", "#{remote}/#{branch}").empty?


### PR DESCRIPTION
This was failing with:

Error: undefined method `dry_run?' for ["boost-python3"]:Array
linuxbrew/Homebrew/Library/Taps/linuxbrew/homebrew-developer/cmd/brew-build-bottle-pr.rb:153:in `block (2 levels) in build_bottle'
linuxbrew/Homebrew/Library/Taps/linuxbrew/homebrew-developer/cmd/brew-build-bottle-pr.rb:150:in `open'