### PR TITLE
Make `brew test-bot` on Azure Pipelines actually succeed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
         sudo chown "$USER" /home/linuxbrew
         git config --global user.name LinuxbrewTestBot
         git config --global user.email testbot@linuxbrew.sh
-        git clone https://github.com/Linuxbrew/brew /home/linuxbrew/.linuxbrew/Homebrew
+        git clone https://github.com/Homebrew/brew /home/linuxbrew/.linuxbrew/Homebrew
         mkdir /home/linuxbrew/.linuxbrew/bin
         ln -s ../Homebrew/bin/brew /home/linuxbrew/.linuxbrew/bin/
         mkdir -p /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/linuxbrew


### PR DESCRIPTION
WIP. Turns out the green tick against the Azure Pipelines run was misleading as it doesn't actually do a thing.