### PR TITLE
build-bottle-pr: We don't need the description in the commit message

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -152,7 +152,7 @@ module Homebrew
       end
       if ARGV.value("dry_run").nil?
         keep_old if ARGV.include? "--keep-old"
-        safe_system "git", "commit", formula.path, "-m", message
+        safe_system "git", "commit", formula.path, "-m", title
         unless Utils.popen_read("git", "branch", "-r", "--list", "#{remote}/#{branch}").empty?
           return odie "#{formula}: Remote branch #{remote}/#{branch} already exists" unless ARGV.force?
           ohai "#{formula}: Removing branch #{branch} from #{remote}" if ARGV.verbose?


### PR DESCRIPTION
- We only need the description in the PR to appease the bot that tells
  us to be more verbose in PR/issue commentary.
- Having it in the commit message caused us to have to strip it out when
  using `brew squash-bottle-pr`, which was a pain. This change was
  suggested in a review by @sjackman on #100.

Co-authored-by: Shaun Jackman <sjackman@gmail.com>