### PR TITLE
merge-homebrew: Make the merge PR description better

### DIFF
--- a/cmd/brew-merge-homebrew.rb
+++ b/cmd/brew-merge-homebrew.rb
@@ -90,7 +90,7 @@ module Homebrew
       conflicts = conflict_files.map { |s| s.gsub(%r{^Formula/|\.rb$}, "") }
       sha1 = Utils.popen_read(git, "rev-parse", "--short", homebrew_commits.last).chomp
       branch = "merge-#{Date.today}-#{sha1}"
-      message = "Merge #{Date.today} #{sha1}\n\nThis merges commits from Homebrew/homebrew-core into Homebrew/linuxbrew-core\n\n" + conflicts.map { |s| "+ [ ] #{s}\n" }.join
+      message = "Merge #{Date.today} #{sha1}\n\nMerge Homebrew/homebrew-core into Homebrew/linuxbrew-core\n\n" + conflicts.map { |s| "+ [ ] #{s}\n" }.join
       hub_pull_request branch, message
     end
   end

--- a/cmd/brew-merge-homebrew.rb
+++ b/cmd/brew-merge-homebrew.rb
@@ -90,7 +90,7 @@ module Homebrew
       conflicts = conflict_files.map { |s| s.gsub(%r{^Formula/|\.rb$}, "") }
       sha1 = Utils.popen_read(git, "rev-parse", "--short", homebrew_commits.last).chomp
       branch = "merge-#{Date.today}-#{sha1}"
-      message = "Merge #{Date.today} #{sha1}\n\n" + conflicts.map { |s| "+ [ ] #{s}\n" }.join
+      message = "Merge #{Date.today} #{sha1}\n\nThis merges commits from Homebrew/homebrew-core into Homebrew/linuxbrew-core\n\n" + conflicts.map { |s| "+ [ ] #{s}\n" }.join
       hub_pull_request branch, message
     end
   end


### PR DESCRIPTION
- At the moment, on the rare occasions when the formulae we merge don't
  have conflicts, the PR description is empty which makes request-info-bot
  in linuxbrew-core complain.