### PR TITLE
azure-pipelines: `git clone Homebrew/brew` not `Linuxbrew/brew`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
         sudo chown "$USER" /home/linuxbrew
         git config --global user.name LinuxbrewTestBot
         git config --global user.email testbot@linuxbrew.sh
-        git clone https://github.com/Linuxbrew/brew /home/linuxbrew/.linuxbrew/Homebrew
+        git clone https://github.com/Homebrew/brew /home/linuxbrew/.linuxbrew/Homebrew
         mkdir /home/linuxbrew/.linuxbrew/bin
         ln -s ../Homebrew/bin/brew /home/linuxbrew/.linuxbrew/bin/
         mkdir -p /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/linuxbrew


### PR DESCRIPTION
- There have been lots of changes that `Homebrew/linuxbrew-core` have in
  formulae that aren't in the archived `Linuxbrew/brew` repo, for
  example:
  ```
    Error: Invalid formula: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/reminiscence.rb
  reminiscence: undefined method `uses_from_macos' for #<Class:0x00000000041f3638>
  ```
- :crossed_fingers: :pray: