### PR TITLE
squash-bottle-pr: Fix bug with determining the author of a bottle commit

### DIFF
--- a/cmd/brew-squash-bottle-pr.rb
+++ b/cmd/brew-squash-bottle-pr.rb
@@ -24,7 +24,7 @@ module Homebrew
     safe_system "sed", "-iorig", "-e", "/^#.*: #{marker}$/d", file
     rm_f file.to_s + "orig"
 
-    author = Utils.popen_read("git", "log", "-n1", "--format=%an <%ae>", "HEAD~1").chomp
+    author = Utils.popen_read("git", "log", "-n1", "--format=%an <%ae>", "HEAD").chomp
     git_editor = ENV["GIT_EDITOR"]
     ENV["GIT_EDITOR"] = "sed -n -i -e 's/.*#{marker}//p;s/^    //p'"
     safe_system "git", "-c", "commit.verbose=false", "commit", "--author", author, file


### PR DESCRIPTION
- The setting for the commit to take the author from was `HEAD~1`, which
  is the "# Build a bottle for Linuxbrew" commit in most cases. These
  commits are authored by maintainers, so then the bottle commits show
  up to be from the previous author, too.
- This accident lead to us artificially inflating the number of
  _authorship_ commits a maintainer has. :-( For an example, see:
  https://github.com/Homebrew/linuxbrew-core/commits/2e7e3d3d46ef09bc308f39b095f54ac2e54ded8f
  - they all show up as from me.
- Instead, the script now determines the author from `HEAD`, which is
  the _current_ bottle SHA commit, which is, at the start, before the
  squash, authored by `LinuxbrewTestBot`.