### PR TITLE
Extract a list of conflicting formulae from the latest merge commit

### DIFF
--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -2,7 +2,7 @@ module Homebrew
   module_function
 
   def on_master?
-    `git rev-parse HEAD` == `git rev-parse master`
+    Utils.popen_read("git", "rev-parse", "--abbrev-ref", "HEAD").chomp == "master"
   end
 
   def head_is_merge_commit?

--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -1,0 +1,37 @@
+module Homebrew
+  module_function
+
+  def head_is_merge_commit?
+    `git log --merges -1 --format=%H`.chomp == `git rev-parse HEAD`.chomp &&
+      `git log --oneline --format=%s -1`.chomp == "Merge branch homebrew/master into linuxbrew/master"
+  end
+
+  def head_has_conflict_lines?
+    `git log --format=%b -1`.chomp.include?("Conflicts:") ||
+      `git log --format=%b -1`.chomp.include?("Formula/")
+  end
+
+  def assemble_list_of_formulae_to_bottle
+    `git log --format=%b -1`.each_line do |line|
+      line.strip!
+      next if line.empty? || line == "Conflicts:"
+
+      @formulae_to_bottle.push(line.split('/')[1].split('.')[0])
+    end
+  end
+
+  @formulae_to_bottle = []
+
+  if head_is_merge_commit?
+    if head_has_conflict_lines?
+      assemble_list_of_formulae_to_bottle
+      puts @formulae_to_bottle
+    else
+      puts "HEAD does not have any bottles to build for new versions, aborting."
+      exit 1
+    end
+  else
+    puts "HEAD is not a merge commit, aborting."
+    exit 1
+  end
+end

--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -27,5 +27,5 @@ module Homebrew
     formulae_to_bottle.push(line.split('/')[1].split('.')[0])
   end
 
-  puts @formulae_to_bottle
+  puts formulae_to_bottle
 end

--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -11,12 +11,12 @@ module Homebrew
   end
 
   def head_has_conflict_lines?
-    `git log --format=%b -1`.chomp.include?("Conflicts:") ||
-      `git log --format=%b -1`.chomp.include?("Formula/")
+    @latest_merge_commit_message.include?("Conflicts:") ||
+      @latest_merge_commit_message.include?("Formula/")
   end
 
   def assemble_list_of_formulae_to_bottle
-    `git log --format=%b -1`.each_line do |line|
+    @latest_merge_commit_message.each_line do |line|
       line.strip!
       next if line.empty? || line == "Conflicts:"
 
@@ -27,6 +27,7 @@ module Homebrew
   odie "You need to be on the master branch to run this." unless on_master?
 
   @formulae_to_bottle = []
+  @latest_merge_commit_message = `git log --format=%b -1`.chomp
 
   if head_is_merge_commit?
     if head_has_conflict_lines?

--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -1,6 +1,10 @@
 module Homebrew
   module_function
 
+  def on_master?
+    `git rev-parse HEAD` == `git rev-parse master`
+  end
+
   def head_is_merge_commit?
     `git log --merges -1 --format=%H`.chomp == `git rev-parse HEAD`.chomp &&
       `git log --oneline --format=%s -1`.chomp == "Merge branch homebrew/master into linuxbrew/master"
@@ -19,6 +23,8 @@ module Homebrew
       @formulae_to_bottle.push(line.split('/')[1].split('.')[0])
     end
   end
+
+  odie "You need to be on the master branch to run this." unless on_master?
 
   @formulae_to_bottle = []
 

--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -6,38 +6,26 @@ module Homebrew
   end
 
   def head_is_merge_commit?
-    `git log --merges -1 --format=%H`.chomp == `git rev-parse HEAD`.chomp
+    Utils.popen_read("git", "log", "--merges", "-1", "--format=%H").chomp == Utils.popen_read("git", "rev-parse", "HEAD").chomp
   end
 
-  def head_has_conflict_lines?
-    @latest_merge_commit_message.include?("Conflicts:") ||
-      @latest_merge_commit_message.include?("Formula/")
+  def head_has_conflict_lines?(commit_message)
+    commit_message.include?("Conflicts:") || commit_message.include?("Formula/")
   end
 
-  def assemble_list_of_formulae_to_bottle
-    @latest_merge_commit_message.each_line do |line|
-      line.strip!
-      next if line.empty? || line == "Conflicts:"
-
-      @formulae_to_bottle.push(line.split('/')[1].split('.')[0])
-    end
-  end
+  formulae_to_bottle = []
+  latest_merge_commit_message = Utils.popen_read("git", "log", "--format=%b", "-1").chomp
 
   odie "You need to be on the master branch to run this." unless on_master?
+  odie "HEAD is not a merge commit." unless head_is_merge_commit?
+  odie "HEAD does not have any bottles to build for new versions." unless head_has_conflict_lines?(latest_merge_commit_message)
 
-  @formulae_to_bottle = []
-  @latest_merge_commit_message = `git log --format=%b -1`.chomp
+  latest_merge_commit_message.each_line do |line|
+    line.strip!
+    next if line.empty? || line == "Conflicts:"
 
-  if head_is_merge_commit?
-    if head_has_conflict_lines?
-      assemble_list_of_formulae_to_bottle
-      puts @formulae_to_bottle
-    else
-      puts "HEAD does not have any bottles to build for new versions, aborting."
-      exit 1
-    end
-  else
-    puts "HEAD is not a merge commit, aborting."
-    exit 1
+    formulae_to_bottle.push(line.split('/')[1].split('.')[0])
   end
+
+  puts @formulae_to_bottle
 end

--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -24,7 +24,8 @@ module Homebrew
     line.strip!
     next if line.empty? || line == "Conflicts:"
 
-    formulae_to_bottle.push(line.split('/')[1].split('.')[0])
+    formula = line[%r{Formula/(.*).rb$}, 1]
+    formulae_to_bottle.push(formula) if formula
   end
 
   puts formulae_to_bottle

--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -6,8 +6,7 @@ module Homebrew
   end
 
   def head_is_merge_commit?
-    `git log --merges -1 --format=%H`.chomp == `git rev-parse HEAD`.chomp &&
-      `git log --oneline --format=%s -1`.chomp == "Merge branch homebrew/master into linuxbrew/master"
+    `git log --merges -1 --format=%H`.chomp == `git rev-parse HEAD`.chomp
   end
 
   def head_has_conflict_lines?


### PR DESCRIPTION
- For every merge between Homebrew/homebrew-core and Homebrew/linuxbrew-core we do, there are conflicting formulae, mostly in the `bottle do` blocks. For every one of those conflicitng formulae, we have to do `brew build-bottle-pr`. To do this, we have to copy/paste every conflicting formula line from the commit message/PR description as an argument to `brew build-bottle-pr`, which gets tedious.
- For every merge commit (nothing sophisticated, just "does it start with 'Merge branch homebrew/master into linuxbrew/master'?"), this script will trim the Conflict lines if there are any and output a list of formulae to stdout.
- For building bottle PRs from that list, you can then use a bash for loop, like:
  `for i in $(brew find-formulae-to-bottle); do brew build-bottle-pr $i; done`.

Enhancements I have in mind for the future:

- Sometimes, we like to merge multiple swaths of commits between Homebrew and Linuxbrew at once, and build bottles for _all the formulae_ at the end. This currently only looks at the _latest_ commit to see if it's a merge commit. This could, in future:
  - Find all the commits that are merge commits _since the last bottle commits_.
  - Iterate over them, and add to the @formulae_to_bottle array so then at the end of all the Merge commits, we can bottle everything in one go.
- This also feels like it would aid in the implementation of a GitHub Action which, on merges to master, will auto-build bottles.

This has been tested with the bottles from a recent merge commit, and it works.