### PR TITLE
find-formulae-to-bottle: Skip commit message lines that aren't "Formula/thing.rb"

### DIFF
--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -22,7 +22,7 @@ module Homebrew
 
   latest_merge_commit_message.each_line do |line|
     line.strip!
-    next if line.empty? || line == "Conflicts:"
+    next unless line.include?("Formula/")
 
     formula = line[%r{Formula/(.*).rb$}, 1]
     formulae_to_bottle.push(formula) if formula


### PR DESCRIPTION
- Addresses [a comment from review of #108](https://github.com/Linuxbrew/homebrew-developer/pull/108#pullrequestreview-272105278).