### PR TITLE
Refactor bits of build-bottle-pr into find-formulae-to-bottle

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -1,4 +1,4 @@
-#:  * `build-bottle-pr` [`--remote=<user>`] [`--limit=<num>`] [`--dry-run`] [`--verbose`] [`--force`]:
+#:  * `build-bottle-pr` [`--remote=<user>`] [`--limit=<num>`] [`--dry-run`] [`--verbose`] [`--tap-dir`] [`--force`]:
 #:    Submit a pull request to build a bottle for a formula.
 #:
 #:    If `--remote` is passed, use the specified GitHub remote. Otherwise, use `origin`.
@@ -47,9 +47,6 @@ module Homebrew
   def build_bottle(formula)
     @n += 1
     return ohai "#{formula}: Skipping because GitHub rate limits pull requests (limit = #{limit})." if @n > limit
-
-    system HOMEBREW_BREW_FILE, "audit", formula.path
-    opoo "Please fix audit failure for #{formula}" unless $CHILD_STATUS.success?
 
     title = "#{formula}: Build a bottle for Linuxbrew"
     message = <<~EOS

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -92,6 +92,8 @@ module Homebrew
   end
 
   def build_bottle_pr
+    ENV["HOMEBREW_DISABLE_LOAD_FORMULA"] = "1"
+
     odie "Please install hub (brew install hub) before proceeding" unless which "hub"
     odie "No formula has been specified" unless formula
 

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -59,6 +59,7 @@ module Homebrew
 
     branch = "bottle-#{formula}"
     cd tap_dir do
+      formula_path = "Formula/#{formula}.rb"
       unless Utils.popen_read("git", "branch", "--list", branch).empty?
         return odie "#{formula}: Branch #{branch} already exists" unless ARGV.force?
 
@@ -66,13 +67,13 @@ module Homebrew
         safe_system "git", "branch", "-D", branch
       end
       safe_system "git", "checkout", "-b", branch, "master"
-      File.open(formula.path, "r+") do |f|
+      File.open(formula_path, "r+") do |f|
         s = f.read
         f.rewind
         f.write "# #{title}\n#{s}" if ARGV.value("dry_run").nil?
       end
       if ARGV.value("dry_run").nil?
-        safe_system "git", "commit", formula.path, "-m", title
+        safe_system "git", "commit", formula_path, "-m", title
         unless Utils.popen_read("git", "branch", "-r", "--list", "#{remote}/#{branch}").empty?
           return odie "#{formula}: Remote branch #{remote}/#{branch} already exists" unless ARGV.force?
 

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -87,28 +87,12 @@ module Homebrew
     end
   end
 
-  def shell(cmd)
-    output = `#{cmd}`
-    raise ErrorDuringExecution, cmd unless $CHILD_STATUS.success?
-
-    output
-  end
-
-  def brew(args)
-    shell "#{HOMEBREW_PREFIX}/bin/brew #{args}"
-  end
-
   def build_bottle_pr
     odie "Please install hub (brew install hub) before proceeding" unless which "hub"
     odie "No formula has been specified" if ARGV.formulae.empty?
 
     formulae = ARGV.formulae
-    unless ARGV.one?
-      deps = brew("deps -n --union #{formulae.join " "}").split
-      ohai "Adding following dependencies: #{deps.join ", "}" if ARGV.verbose? && !deps.empty?
-      formulae = deps.map { |f| Formula[f] } + formulae
-    end
-    formulae.each { |f| build_bottle f }
+    formulae.each { |f| build_bottle(f) }
   end
 end
 

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -14,17 +14,6 @@ require "English"
 module Homebrew
   module_function
 
-  def open_pull_request?(formula)
-    prs = GitHub.issues_for_formula(formula,
-      type: "pr", state: "open", repo: slug(formula.tap))
-    prs = prs.select { |pr| pr["title"].start_with? "#{formula}: " }
-    if prs.any?
-      opoo "#{formula}: Skipping because a PR is open"
-      prs.each { |pr| puts "#{pr["title"]} (#{pr["html_url"]})" }
-    end
-    prs.any?
-  end
-
   def limit
     @limit ||= (ARGV.value("limit") || "10").to_i
   end
@@ -93,8 +82,6 @@ module Homebrew
     tap_dir = formula.tap.formula_dir
     remote = tap_dir.cd { determine_remote }
     odie "#{formula}: Failed to determine a remote to use for Pull Request" if remote.nil?
-
-    return if open_pull_request? formula
 
     @n += 1
     return ohai "#{formula}: Skipping because GitHub rate limits pull requests (limit = #{limit})." if @n > limit

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -14,6 +14,10 @@ require "English"
 module Homebrew
   module_function
 
+  def formula
+    @formula ||= ARGV.last.to_s
+  end
+
   def limit
     @limit ||= (ARGV.value("limit") || "10").to_i
   end
@@ -89,10 +93,9 @@ module Homebrew
 
   def build_bottle_pr
     odie "Please install hub (brew install hub) before proceeding" unless which "hub"
-    odie "No formula has been specified" if ARGV.formulae.empty?
+    odie "No formula has been specified" unless formula
 
-    formulae = ARGV.formulae
-    formulae.each { |f| build_bottle(f) }
+    build_bottle(formula)
   end
 end
 

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -5,6 +5,7 @@
 #:    If `--limit` is passed, make at most the specified number of PR's at once. Defaults to 10.
 #:    If `--dry-run` is passed, do not actually make any PR's.
 #:    If `--verbose` is passed, print extra information.
+#:    If `--tap-dir` is passed, use the specified full path to a tap. Otherwise, use the Linuxbrew standard install location.
 #:    If `--force` is passed, delete local and remote 'bottle-<name>' branches if they exist. Use with care.
 #:    If `--browse` is passed, open a web browser for the new pull request.
 
@@ -19,6 +20,10 @@ module Homebrew
 
   def remote
     @remote ||= ARGV.value("remote") || "origin"
+  end
+
+  def tap_dir
+    @tap_dir ||= ARGV.value("tap-dir") || "/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core"
   end
 
   # Open a pull request using hub.

--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -27,8 +27,19 @@ module Homebrew
     formula.requirements.any? { |req| (req.instance_of? MacOSRequirement) && !req.version_specified? }
   end
 
+  def open_pull_request?(formula)
+    prs = GitHub.issues_for_formula(formula,
+      type: "pr", state: "open", repo: slug(formula.tap))
+    prs = prs.select { |pr| pr["title"].start_with? "#{formula}: " }
+    if prs.any?
+      opoo "#{formula}: Skipping because a PR is open"
+      prs.each { |pr| puts "#{pr["title"]} (#{pr["html_url"]})" }
+    end
+    prs.any?
+  end
+
   def should_not_build_linux_bottle?(formula, tag)
-    depends_on_macos?(formula) || formula.bottle_unneeded? || formula.bottle_disabled? || formula.bottle_specification.tag?(tag) || slug(formula.tap) == "Homebrew/homebrew-core"
+    depends_on_macos?(formula) || formula.bottle_unneeded? || formula.bottle_disabled? || formula.bottle_specification.tag?(tag) || slug(formula.tap) == "Homebrew/homebrew-core" || open_pull_request?(formula)
   end
 
   formulae_to_bottle = []

--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -1,3 +1,9 @@
+#:  * `find-formulae-to-bottle` [`--verbose`]:
+#:    Find conflicting formulae from the latest merge commit.
+#:    Outputs a list that can be passed to `brew build-bottle-pr`.
+#:
+#:    If `--verbose` is passed, print debugging information (eg if a formula already has a bottle PR open).
+
 module Homebrew
   module_function
 
@@ -31,15 +37,24 @@ module Homebrew
     prs = GitHub.issues_for_formula(formula,
       type: "pr", state: "open", repo: slug(formula.tap))
     prs = prs.select { |pr| pr["title"].start_with? "#{formula}: " }
-    if prs.any?
+    if prs.any? && ARGV.verbose?
       opoo "#{formula}: Skipping because a PR is open"
-      prs.each { |pr| puts "#{pr["title"]} (#{pr["html_url"]})" }
+      prs.each { |pr| ohai "#{pr["title"]} (#{pr["html_url"]})" }
     end
     prs.any?
   end
 
   def should_not_build_linux_bottle?(formula, tag)
     depends_on_macos?(formula) || formula.bottle_unneeded? || formula.bottle_disabled? || formula.bottle_specification.tag?(tag) || slug(formula.tap) == "Homebrew/homebrew-core" || open_pull_request?(formula)
+  end
+
+  def reason_to_not_build_bottle(formula, tag)
+    return opoo "#{formula}: Skipping because it depends on macOS" if depends_on_macos?(formula)
+    return opoo "#{formula}: Skipping because a bottle is not needed" if formula.bottle_unneeded?
+    return opoo "#{formula}: Skipping because bottles are disabled" if formula.bottle_disabled?
+    return opoo "#{formula}: Skipping because it has a bottle already" if formula.bottle_specification.tag?(tag)
+    return opoo "#{formula}: Skipping because #{formula.tap} does not support Linux" if slug(formula.tap) == "Homebrew/homebrew-core"
+    return if open_pull_request?(formula)
   end
 
   formulae_to_bottle = []
@@ -51,14 +66,17 @@ module Homebrew
 
   latest_merge_commit_message.each_line do |line|
     line.strip!
-    formula = line[%r{Formula/(.*).rb$}, 1]
-    formulae_to_bottle.push(formula) if formula
+
+    @formula = line[%r{Formula/(.*).rb$}, 1]
+    formulae_to_bottle.push(@formula) if @formula
   end
 
   tag = (ARGV.value("tag") || "x86_64_linux").to_sym
   formulae_to_bottle.reject! do |formula|
     should_not_build_linux_bottle?(Formula[formula], tag)
   end
+
+  reason_to_not_build_bottle(Formula[@formula], tag) if ARGV.verbose?
 
   puts formulae_to_bottle
 end

--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -13,6 +13,24 @@ module Homebrew
     commit_message.include?("Conflicts:") || commit_message.include?("Formula/")
   end
 
+  # The GitHub slug of the {Tap}.
+  # Not simply tap.full_name, because the slug of homebrew/core
+  # may be either Homebrew/homebrew-core or Homebrew/linuxbrew-core.
+  def slug(tap)
+    return tap.full_name unless tap.remote
+
+    x = tap.remote[%r{^https://github\.com/([^.]+)(\.git)?$}, 1]
+    (tap.official? && !x.nil?) ? x.capitalize : x
+  end
+
+  def depends_on_macos?(formula)
+    formula.requirements.any? { |req| (req.instance_of? MacOSRequirement) && !req.version_specified? }
+  end
+
+  def should_not_build_linux_bottle?(formula, tag)
+    depends_on_macos?(formula) || formula.bottle_unneeded? || formula.bottle_disabled? || formula.bottle_specification.tag?(tag) || slug(formula.tap) == "Homebrew/homebrew-core"
+  end
+
   formulae_to_bottle = []
   latest_merge_commit_message = Utils.popen_read("git", "log", "--format=%b", "-1").chomp
 
@@ -22,10 +40,13 @@ module Homebrew
 
   latest_merge_commit_message.each_line do |line|
     line.strip!
-    next unless line.include?("Formula/")
-
     formula = line[%r{Formula/(.*).rb$}, 1]
     formulae_to_bottle.push(formula) if formula
+  end
+
+  tag = (ARGV.value("tag") || "x86_64_linux").to_sym
+  formulae_to_bottle.reject! do |formula|
+    should_not_build_linux_bottle?(Formula[formula], tag)
   end
 
   puts formulae_to_bottle


### PR DESCRIPTION
- In doing https://github.com/Homebrew/linuxbrew-core/pull/14838 (a GitHub Action for `brew
  build-bottle-pr`), concerns were raised about a bot with access to our
  repos being able to rewrite formulae and bottle PRs.
- In this refactor, all of the `brew` "check these things about these
  formulae to see if they're OK to bottle" is done in the
  `find-formulae-to-bottle` step, rather than the `brew
  build-bottle-pr`, so the script that writes commits and raises pull
  requests doesn't have to run any `brew` commands itself, so the
  formulae are never loaded.
- I think I've taken everything necessary out - things seem to work. I
  also reject formulae that can't be bottled, which removes them from the
  final list of formulae that are shown for `brew build-bottle-pr`.