### PR TITLE
squash-bottle-pr: Hardcode the commit author as LinuxbrewTestBot

### DIFF
--- a/cmd/brew-squash-bottle-pr.rb
+++ b/cmd/brew-squash-bottle-pr.rb
@@ -24,7 +24,7 @@ module Homebrew
     safe_system "sed", "-iorig", "-e", "/^#.*: #{marker}$/d", file
     rm_f file.to_s + "orig"
 
-    author = Utils.popen_read("git", "log", "-n1", "--format=%an <%ae>", "HEAD").chomp
+    author = "LinuxbrewTestBot <testbot@linuxbrew.sh>"
     git_editor = ENV["GIT_EDITOR"]
     ENV["GIT_EDITOR"] = "sed -n -i -e 's/.*#{marker}//p;s/^    //p'"
     safe_system "git", "-c", "commit.verbose=false", "commit", "--author", author, file


### PR DESCRIPTION
- We programatically determined this in
  https://github.com/Linuxbrew/homebrew-developer/pull/100 because
  bottle commits appeared to be authored by whichever maintainer was
  pulling the bottle.
- That didn't work 100% accurately, so we tried to fix it to pull from
  the _bottle commit itself_ before the squash - ie always authored by
  LinuxbrewTestBot. That happened in
  https://github.com/Linuxbrew/homebrew-developer/pull/107, and also
  didn't work 100% reliably.
- Let's cut our losses and stop the mis-authoring of bottle commits
  by hardcoding `LinuxbrewTestBot` as the author. Given that this script
  is used when maintainers pull bottle commits AND the PR that made the
  bottle commit happen was a simple `# Build a bottle for Linuxbrew`
  commit which gets rebased away, we will never be in a situation where
  _users_, who deserve credit, get their commits to fix builds authored
  by `LinuxbrewTestBot`.