### PR TITLE
build-bottle-pr: Make the `--remote` argument mandatory

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -18,7 +18,7 @@ module Homebrew
   end
 
   def remote
-    @remote ||= ARGV.value("remote") || "origin"
+    @remote ||= ARGV.value("remote")
   end
 
   def tap_dir
@@ -85,6 +85,7 @@ module Homebrew
 
     odie "Please install hub (brew install hub) before proceeding" unless which "hub"
     odie "No formula has been specified" unless formula
+    odie "No remote has been specified: use `--remote=origin` or `--remote=$HOMEBREW_GITHUB_USER`" unless remote
 
     build_bottle(formula)
   end

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -18,7 +18,7 @@ module Homebrew
   end
 
   def remote
-    @remote ||= ARGV.value("remote")
+    @remote ||= ARGV.value("remote") || ENV["HOMEBREW_GITHUB_USER"]
   end
 
   def tap_dir


### PR DESCRIPTION
- This will no longer default to `origin`. I preferred it when it did,
  but this is based on feedback in
  https://github.com/Homebrew/brew/pull/6448#discussion_r324248081.
- Now, the GitHub Action can employ the same syntax as local maintainer
  usage:
  - `brew build-bottle-pr --remote=origin formula`
  - `brew build-bottle-pr --remote=$HOMEBREW_GITHUB_USER formula`