### PR TITLE
Remove "Documentation" section from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ Tools for Linuxbrew developers
 brew tap linuxbrew/developer
 ```
 
-## Documentation
-
-Linuxbrew developers' guides and procedures
-
-+ **merge-homebrew-core.md**: Documentation for `merge-homebrew` command
-
 ## Adding new tools
 
 Read the ["External Commands" Linuxbrew document](https://github.com/Linuxbrew/brew/blob/master/docs/External-Commands.md) to see how to create Homebrew external commands.


### PR DESCRIPTION
- The documentation has been moved to Homebrew/brew in the [Homebrew/linuxbrew-core Maintainer Guide](https://docs.brew.sh/Homebrew-linuxbrew-core-Maintainer-Guide).